### PR TITLE
Support newer requests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,11 @@
+## ChangeLog
+
+### 0.1.7
+* Downgrade requests version to ensure compatibility with current code
+
+### 0.1.6
+* Update setup.py to only include the actual requirements needed to install. Thanks to Toshio Kuratomi (https://github.com/jakul/python-transifex/pull/3)
+* Fix tests which now throw InvalidSlugException. Thanks to Toshio Kuratmi (https://github.com/jakul/python-transifex/pull/4)
+
+### 0.1.5
+* add new InvalidSlugException; make exceptions share a base class

--- a/README.md
+++ b/README.md
@@ -16,11 +16,62 @@ To connect to transifex:
     In [4]: t.ping()
     Out[4]: True
 
-### Create a new public project
+### Projects
+#### Create a new public project
 
 Public projects require a `repository_url`. This can be any valid URL. 
 Private projects do mnot require this, but you must have a Transifex plan 
 which allows private projects.
 
     In [3]: t.new_project('helloworld5', repository_url='http://gmail.com')
+    
+#### Check if a project already exists
+
+    In [9]: t.project_exists('helloworld5')
+    Out[9]: True
+    
+    In [10]: t.project_exists('helloworld44345')
+    Out[10]: False
+
+### Resources
+#### List resources
+
+    In [13]: t.list_resources('helloworld5')
+    Out[13]: 
+    [{u'categories': None,
+      u'i18n_type': u'PO',
+      u'name': u'pofilepo',
+      u'priority': u'1',
+      u'slug': u'pofilepo',
+      u'source_language_code': u'en_GB'}]
+
+
+#### Create a resource
+
+    In [16]: t.new_resource('helloworld5', '/src/python-transifex/pofile.po', resource_slug='anotherpofile')            
+    t.new_translation('helloworld5, 'pofilepo', 'pt-br','/src/python-transifex/pofile.po'):
+
+#### Delete a resource
+
+    In [17]: t.delete_resource('helloworld5', 'anotherpofile')
+
+#### List the languages this resource is translated into
+
+    In [20]: t.list_languages('helloworld5', 'pofilepo')
+    Out[20]: [u'en_GB']
+
+
+#### Uploading translations to Transifex
+
+    In [22]: t.new_translation('helloworld5', 'pofilepo', 'pt-br','/src/python-transifex/pofile.po')
+    Out[22]: 
+    {u'redirect': u'/projects/p/helloworld5/resource/pofilepo/',
+     u'strings_added': 0,
+     u'strings_delete': 0,
+     u'strings_updated': 0}
+
+
+#### Downloading translations from Transifex
+
+    In [23]: t.get_translation('helloworld5', 'pofilepo', 'pt-br', '/src/python-transifex/pofile_ptbr.po')
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-python-transifex
-----------------
+# python-transifex
 A python API to the Transifex translation service (www.transifex.com). This API wrapper makes it easier to communicate with Transifex. The wrapper does not expose all of the underlying functionality of the Transifex API.
 
 This wrapper is compatible with both www.transifex.com and Transifex Community Edition (self hosted).
 
-ChangeLog
----------
-0.1.7
-=====
-* Downgrade requests version to ensure compatibility with current code
+## Usage
 
-0.1.6
-=====
-* Update setup.py to only include the actual requirements needed to install. Thanks to Toshio Kuratomi (https://github.com/jakul/python-transifex/pull/3)
-* Fix tests which now throw InvalidSlugException. Thanks to Toshio Kuratmi (https://github.com/jakul/python-transifex/pull/4)
+### Authentication
 
-0.1.5
-=====
-* add new InvalidSlugException; make exceptions share a base class
+
+To connect to transifex:
+
+    In [2]: from transifex.api import TransifexAPI
+    
+    In [3]: t = Tr
+    TransifexAPI  True          
+    
+    # Replace `username` and `password` here with your own username and password
+    In [3]: t = TransifexAPI('username', 'password', 'http://transifex.com')
+    
+    In [4]: t.ping()
+    Out[4]: True

--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ This wrapper is compatible with both www.transifex.com and Transifex Community E
 ## Usage
 
 ### Authentication
-
-
 To connect to transifex:
 
     In [2]: from transifex.api import TransifexAPI
-    
-    In [3]: t = Tr
-    TransifexAPI  True          
     
     # Replace `username` and `password` here with your own username and password
     In [3]: t = TransifexAPI('username', 'password', 'http://transifex.com')
     
     In [4]: t.ping()
     Out[4]: True
+
+### Create a new public project
+
+Public projects require a `repository_url`. This can be any valid URL. 
+Private projects do mnot require this, but you must have a Transifex plan 
+which allows private projects.
+
+    In [3]: t.new_project('helloworld5', repository_url='http://gmail.com')
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To connect to transifex:
 
 ### Projects
 #### Create a new public project
-
 Public projects require a `repository_url`. This can be any valid URL. 
 Private projects do mnot require this, but you must have a Transifex plan 
 which allows private projects.
@@ -34,6 +33,8 @@ which allows private projects.
     Out[6]: False
 
 ### Resources
+A resource is a set of strings which need to be translated into one or more 
+other languages.
 
 #### Create a resource
 
@@ -54,6 +55,7 @@ which allows private projects.
 #### Delete a resource
 
     In [9]: t.delete_resource('helloworld5', 'anotherpofile')
+    
 
 #### List the languages this resource is translated into
 
@@ -65,6 +67,9 @@ which allows private projects.
 
 
 #### Uploading translations to Transifex
+If you have up to date translations in your codebase, you should update them to 
+Transifex so that the translators don't have to translate everything from 
+scratch.
 
     In [12]: t.new_translation('helloworld5', 'pofilepo', 'pt-br','/src/python-transifex/pofile.po')
     Out[12]: 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This wrapper is compatible with both www.transifex.com and Transifex Community E
 ### Authentication
 To connect to transifex:
 
-    In [2]: from transifex.api import TransifexAPI
+    In [1]: from transifex.api import TransifexAPI
     
     # Replace `username` and `password` here with your own username and password
-    In [3]: t = TransifexAPI('username', 'password', 'http://transifex.com')
+    In [2]: t = TransifexAPI('username', 'password', 'http://transifex.com')
     
-    In [4]: t.ping()
-    Out[4]: True
+    In [3]: t.ping()
+    Out[3]: True
 
 ### Projects
 #### Create a new public project
@@ -23,48 +23,51 @@ Public projects require a `repository_url`. This can be any valid URL.
 Private projects do mnot require this, but you must have a Transifex plan 
 which allows private projects.
 
-    In [3]: t.new_project('helloworld5', repository_url='http://gmail.com')
+    In [4]: t.new_project('helloworld5', repository_url='http://gmail.com')
     
 #### Check if a project already exists
 
-    In [9]: t.project_exists('helloworld5')
-    Out[9]: True
+    In [5]: t.project_exists('helloworld5')
+    Out[5]: True
     
-    In [10]: t.project_exists('helloworld44345')
-    Out[10]: False
+    In [6]: t.project_exists('helloworld44345')
+    Out[6]: False
 
 ### Resources
-#### List resources
-
-    In [13]: t.list_resources('helloworld5')
-    Out[13]: 
-    [{u'categories': None,
-      u'i18n_type': u'PO',
-      u'name': u'pofilepo',
-      u'priority': u'1',
-      u'slug': u'pofilepo',
-      u'source_language_code': u'en_GB'}]
-
 
 #### Create a resource
 
-    In [16]: t.new_resource('helloworld5', '/src/python-transifex/pofile.po', resource_slug='anotherpofile')            
-    t.new_translation('helloworld5, 'pofilepo', 'pt-br','/src/python-transifex/pofile.po'):
+    In [7]: t.new_resource('helloworld5', '/src/python-transifex/pofile.po', resource_slug='anotherpofile')
+    
+#### List resources
+
+    In [8]: t.list_resources('helloworld5')
+    Out[8]: 
+    [{u'categories': None,
+      u'i18n_type': u'PO',
+      u'name': u'anotherpofile',
+      u'priority': u'1',
+      u'slug': u'anotherpofile',
+      u'source_language_code': u'en_GB'}]
+
 
 #### Delete a resource
 
-    In [17]: t.delete_resource('helloworld5', 'anotherpofile')
+    In [9]: t.delete_resource('helloworld5', 'anotherpofile')
 
 #### List the languages this resource is translated into
 
-    In [20]: t.list_languages('helloworld5', 'pofilepo')
-    Out[20]: [u'en_GB']
+    # First, recreate the resource on the Tranisfex server
+    in [10]: t.new_resource('helloworld5', '/src/python-transifex/pofile.po')
+    
+    In [11]: t.list_languages('helloworld5', 'pofilepo')
+    Out[11]: [u'en_GB']
 
 
 #### Uploading translations to Transifex
 
-    In [22]: t.new_translation('helloworld5', 'pofilepo', 'pt-br','/src/python-transifex/pofile.po')
-    Out[22]: 
+    In [12]: t.new_translation('helloworld5', 'pofilepo', 'pt-br','/src/python-transifex/pofile.po')
+    Out[12]: 
     {u'redirect': u'/projects/p/helloworld5/resource/pofilepo/',
      u'strings_added': 0,
      u'strings_delete': 0,
@@ -72,6 +75,6 @@ which allows private projects.
 
 
 #### Downloading translations from Transifex
+To download the translations and store them in a local file run the following:
 
-    In [23]: t.get_translation('helloworld5', 'pofilepo', 'pt-br', '/src/python-transifex/pofile_ptbr.po')
-
+    In [13]: t.get_translation('helloworld5', 'pofilepo', 'pt-br', '/src/python-transifex/pofile_ptbr.po')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==0.12.1
+requests>=0.12.1
 
 # Test requirements
 mock==1.0.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,9 +3,6 @@ from transifex.api import TransifexAPI
 from mock import patch, Mock, MagicMock
 import json
 from transifex.exceptions import InvalidSlugException, TransifexAPIException
-import StringIO
-import requests
-from requests.models import Response
 
 class TransifexAPITest(TestCase):
     

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,27 @@ from mock import patch, Mock, MagicMock
 import json
 from transifex.exceptions import InvalidSlugException, TransifexAPIException
 
+
+
+def _check_for_new_project_kwargs(*args, **kwargs):
+    response = Mock()
+    data = json.loads(kwargs.get('data', "{}"))
+    required_kwargs = ['source_language_code', 'name', 'slug',
+                       'repository_url', 'private']
+    missing_keys = set(required_kwargs) - set(data.keys())
+    print(data)
+    if missing_keys:
+        response.status_code = 400
+        response.content = missing_keys
+    elif not data['private'] and data['repository_url'] is None:
+        response.status_code = 400
+        response.content = 'repository_url is required for public ' \
+                           'repositories'
+    else:
+        response.status_code = 201
+
+    return response
+
 class TransifexAPITest(TestCase):
     
     def setUp(self):
@@ -14,25 +35,13 @@ class TransifexAPITest(TestCase):
         self.api = TransifexAPI(**data)
         
     @patch('requests.post')
-    def test_new_project_with_required_args(self, mock_requests):
+    def test_new_public_project_with_required_args(self, mock_requests):
         """
         Test creating a new project with only the required arguments
         """
+        mock_requests.side_effect = _check_for_new_project_kwargs
+        self.api.new_project(slug='abc', repository_url='http://abc.com')
 
-        def side_effect(*args, **kwargs):
-            response = Mock()
-            data = json.loads(kwargs.get('data', "{}"))
-            if 'source_language_code' in data and 'name' in data and 'slug' in \
-            data:
-                response.status_code = 201
-            else:
-                response.status_code = 400
-                
-            return response
-        
-        mock_requests.side_effect = side_effect 
-        self.api.new_project(slug='abc')
-    
     def test_new_project_bad_slug(self):
         """
         Test the `new_project` api call when the slug is invalid
@@ -46,7 +55,16 @@ class TransifexAPITest(TestCase):
         self.assertRaises(InvalidSlugException, self.api.new_project,
             slug='%@$'
         )
-        
+
+    def test_new_project_no_repository_url(self):
+        """
+        Test the `new_project` api call when no repository_url is passed to a
+        public project
+        """
+        self.assertRaises(TransifexAPIException, self.api.new_project,
+            slug='fdsfs', private=False
+        )
+
     @patch('requests.post')
     def test_new_project_with_optional_args(self, mock_requests):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-        py26,
-        py27
+        {py26,py27}-requests{0,1,2}
 
 [testenv]
 commands = py.test
@@ -10,4 +9,6 @@ setenv =
 deps =
        mock==1.0.1
        pytest==2.6.4
-       requests==0.12.1
+       requests0: requests==0.14.2
+       requests1: requests==1.2.3
+       requests2: requests==2.5.1

--- a/transifex/api.py
+++ b/transifex/api.py
@@ -14,7 +14,8 @@ class TransifexAPI(object):
         @param username the username to use when connecting
         @param password the password to use when connecting
         @param host the host string
-        """            
+        """
+        #TODO: make host optional
         self._username = username
         self._password = password
         self._host = host
@@ -26,7 +27,8 @@ class TransifexAPI(object):
         self._base_api_url = '%s/api/2' % (self._host)
 
     def new_project(self, slug, name=None, source_language_code=None,
-                    outsource_project_name=None):
+                    outsource_project_name=None, private=False,
+                    repository_url=None):
         """
         Create a new project on transifex
         
@@ -38,13 +40,18 @@ class TransifexAPI(object):
             the source language code, defaults to 'en-gb'
         @param outsource_project_name (optional)
             the name of the project to outsource translation team management to
+        @param private (optional)
+            controls if this is created as a closed source or open-source
+            project, defaults to `False`
+        @param repository_url (optional)
+            The url for the repository. This is required if private is set to
+            False
             
         @returns None
            
         @raises `TransifexAPIException`
            if project was not created properly
         """
-        
         if slug != slugify(slug):
             raise InvalidSlugException('%r is not a valid slug' % (slug))
         if name is None:
@@ -56,30 +63,19 @@ class TransifexAPI(object):
         headers = {'content-type': 'application/json'}
         data = {
             'name': name, 'slug': slug,
-            'source_language_code': source_language_code, 'description': name
+            'source_language_code': source_language_code, 'description': name,
+            'private': private, 'repository_url': repository_url
         }
         if outsource_project_name is not None:
             data['outsource'] = outsource_project_name
-#        description
-#        long_description
-#        private
-#        homepage
-#        feed
-#        anyone_submit
-#        hidden
-#        bug_tracker
-#        trans_instructions
-#        tags
-#        maintainers
-        
+
         response = requests.post(
              url, data=json.dumps(data), auth=self._auth, headers=headers,
-             
         )
         
         if response.status_code != requests.codes['CREATED']:
             raise TransifexAPIException(response)
-     
+
     def list_resources(self, project_slug):
         """
         List all resources in a project

--- a/transifex/api.py
+++ b/transifex/api.py
@@ -140,13 +140,6 @@ class TransifexAPI(object):
             'name': resource_name, 'slug': resource_slug, 'content': content,
             'i18n_type': 'PO'
         }
-#        slug
-#        name
-#        accept_translations
-#        source_language
-#        mimetype
-#        content (in case of sending the content as one string)
-#        category
 
         response = requests.post(
              url, data=json.dumps(data), auth=self._auth, headers=headers,


### PR DESCRIPTION
* Move `CHANGELOG` to `HISTORY.md`
* Update `README.md` with API description
* Allow project to work with any installed version of requests
* Update `create_new_project` to work with new required argument `private`
* Add tox configs for requests version 0, 1 and 2