### PR TITLE
Fix packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(
     url='https://github.com/jakul/python-transifex',
     license='BSD',
     packages=find_packages(),
-    install_requires=[],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['requests>=0.12.1'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi jakul,
This PR is about fixing the installtion of transifex using pip overgithub

Actually you can do
pip install git+https://github.com/mardiros/python-transifex.git
then you can use the package transifex.

Actually, if you install transifex from your github:

>>> import transifex
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/guillaume/workspace/venv/ttt-py2/lib/python2.7/site-packages/transifex/__init__.py", line 5, in <module>
    VERSION = open(_version_path).read().rstrip() #rstrip() removes newlines
IOError: [Errno 2] No such file or directory: '/home/guillaume/workspace/venv/ttt-py2/lib/python2.7/site-packages/transifex/version.txt'

This is because you don't include the package data during the installation process. You ave a correct MANIFEST.in but you miss the "include_package_data". 

Furthermore, I don't think this is great to have a version.txt file, you should embed the version number
in the __init__.py and call the variable __version__ as everyone do.
Then, you should not import the package in your setup.py file, you should read it via a regex like here:
https://github.com/mardiros/pyshop/blob/master/setup.py
(This is a project of mine but you can see that in popular projects such as Flask, Celery, ...)
And you shoud do .rst not .md to upload it to pypi.

Can I fix that to for you ?

mardiros